### PR TITLE
feat: new deploys params for ERC20 approve and transfer

### DIFF
--- a/src/services/deploys/erc20/actions/erc20Approve.js
+++ b/src/services/deploys/erc20/actions/erc20Approve.js
@@ -1,0 +1,50 @@
+import { CLPublicKey, CLU256, RuntimeArgs } from 'casper-js-sdk';
+import Erc20ApproveResult from '../../../results/erc20/erc20ApproveResult';
+import AbstractSmartContractStoredByHashDeployParameters
+  from '../../abstractSmartContractStoredByHashDeployParameters';
+
+/**
+ * @constant
+ * @type {string}
+ */
+const entrypoint = 'approve';
+
+/**
+ * @constant
+ * @type {number}
+ */
+const fee = 400000000;
+
+/**
+ * Erc20Approve class
+ * Class used to create DeployParameters for an ERC20 Approve operation
+ */
+export default class Erc20Approve extends AbstractSmartContractStoredByHashDeployParameters {
+  /**
+   * Constructor
+   *
+   * @param {string} activeKey - Current active key in the public hex format
+   * @param {string} amount - Amount of tokens that will be allowed to transfer
+   * @param {string} spender - Public key in the hex format of the spender
+   * @param {string} network - Current network to execute the deployment
+   * @param {string} hash - Current hash of the stored SmartContract
+   * @param {number} ttl - Deploy time to live in hours
+   */
+  constructor(activeKey, amount, spender, network, hash, ttl = 1) {
+    const args = RuntimeArgs.fromMap({
+      spender: CLPublicKey.fromHex(spender),
+      amount: new CLU256(amount),
+    });
+    super(activeKey, network, hash, entrypoint, args, fee, ttl);
+  }
+
+  /**
+   * Get a DeployResult constructor
+   *
+   * @return {DeployResult.constructor} - Return the constructor of a given DeployResult
+   */
+  // eslint-disable-next-line class-methods-use-this
+  get deployResult() {
+    return Erc20ApproveResult;
+  }
+}

--- a/src/services/deploys/erc20/actions/erc20Transfer.js
+++ b/src/services/deploys/erc20/actions/erc20Transfer.js
@@ -1,0 +1,50 @@
+import { CLPublicKey, CLU256, RuntimeArgs } from 'casper-js-sdk';
+import Erc20TransferResult from '../../../results/erc20/erc20TransferResult';
+import AbstractSmartContractStoredByHashDeployParameters
+  from '../../abstractSmartContractStoredByHashDeployParameters';
+
+/**
+ * @constant
+ * @type {string}
+ */
+const entrypoint = 'transfer';
+
+/**
+ * @constant
+ * @type {number}
+ */
+const fee = 500000000;
+
+/**
+ * Erc20Transfer class
+ * Class used to create DeployParameters for an ERC20 Transfer operation
+ */
+export default class Erc20Transfer extends AbstractSmartContractStoredByHashDeployParameters {
+  /**
+   * Constructor
+   *
+   * @param {string} activeKey - Current active key in the public hex format
+   * @param {string} amount - Amount of tokens that will be transferred
+   * @param {string} recipient - Public key in the hex format of the recipient
+   * @param {string} network - Current network to execute the deployment
+   * @param {string} hash - Current hash of the stored SmartContract
+   * @param {number} ttl - Deploy time to live in hours
+   */
+  constructor(activeKey, amount, recipient, network, hash, ttl = 1) {
+    const args = RuntimeArgs.fromMap({
+      recipient: CLPublicKey.fromHex(recipient),
+      amount: new CLU256(amount),
+    });
+    super(activeKey, network, hash, entrypoint, args, fee, ttl);
+  }
+
+  /**
+   * Get a DeployResult constructor
+   *
+   * @return {DeployResult.constructor} - Return the constructor of a given DeployResult
+   */
+  // eslint-disable-next-line class-methods-use-this
+  get deployResult() {
+    return Erc20TransferResult;
+  }
+}

--- a/src/services/deploys/erc20/actions/index.js
+++ b/src/services/deploys/erc20/actions/index.js
@@ -1,0 +1,2 @@
+export { default as Erc20Approve } from './erc20Approve';
+export { default as Erc20Transfer } from './erc20Transfer';

--- a/src/services/deploys/erc20/index.js
+++ b/src/services/deploys/erc20/index.js
@@ -1,0 +1,1 @@
+export * from './actions';

--- a/src/services/deploys/index.js
+++ b/src/services/deploys/index.js
@@ -7,3 +7,4 @@ export { default as KeyManagement } from './keyManagement/keyManagement';
 export { default as SmartContractDeployParameters } from './smartContract/smartContractDeployParameters';
 export { default as TransferDeployParameters } from './transfer/TransferDeployParameters';
 export * from './auction';
+export * from './erc20';

--- a/src/services/results/erc20/erc20ApproveResult.js
+++ b/src/services/results/erc20/erc20ApproveResult.js
@@ -1,0 +1,26 @@
+import DeployResult from '../deployResult';
+
+/**
+ * Erc20ApproveResult class
+ */
+export default class Erc20ApproveResult extends DeployResult {
+  /**
+   * Constructor
+   *
+   * @param {string} hash - DeployHash of the deployment
+   * @param {string} cost - optional cost
+   * @param {string} amount - optional amount
+   */
+  constructor(hash, cost = '0', amount = '0') {
+    super(hash, Erc20ApproveResult.getName(), cost, amount);
+  }
+
+  /**
+   * Retrieve the name of the operation behind the deployment
+   *
+   * @return {string} - the name of the operation behind the deployment
+   */
+  static getName() {
+    return 'ERC20 Approve Operation';
+  }
+}

--- a/src/services/results/erc20/erc20TransferResult.js
+++ b/src/services/results/erc20/erc20TransferResult.js
@@ -1,0 +1,26 @@
+import DeployResult from '../deployResult';
+
+/**
+ * Erc20TransferResult class
+ */
+export default class Erc20TransferResult extends DeployResult {
+  /**
+   * Constructor
+   *
+   * @param {string} hash - DeployHash of the deployment
+   * @param {string} cost - optional cost
+   * @param {string} amount - optional amount
+   */
+  constructor(hash, cost = '0', amount = '0') {
+    super(hash, Erc20TransferResult.getName(), cost, amount);
+  }
+
+  /**
+   * Retrieve the name of the operation behind the deployment
+   *
+   * @return {string} - the name of the operation behind the deployment
+   */
+  static getName() {
+    return 'ERC20 Transfer Operation';
+  }
+}

--- a/src/services/results/erc20/index.js
+++ b/src/services/results/erc20/index.js
@@ -1,0 +1,2 @@
+export { default as Erc20ApproveResult } from './erc20ApproveResult';
+export { default as Erc20TransferResult } from './erc20TransferResult';

--- a/src/services/results/index.js
+++ b/src/services/results/index.js
@@ -7,3 +7,4 @@ export { default as SmartContractResult } from './smartContractResult';
 export { default as TransferResult } from './transferResult';
 export { default as UndelegateResult } from './undelegateResult';
 export { default as WithdrawBidResult } from './withdrawBidResult';
+export * from './erc20';

--- a/tests/erc20Operations.test.js
+++ b/tests/erc20Operations.test.js
@@ -1,0 +1,31 @@
+import { DeployUtil } from 'casper-js-sdk';
+import Erc20Approve from '../src/services/deploys/erc20/actions/erc20Approve';
+import Erc20Transfer from '../src/services/deploys/erc20/actions/erc20Transfer';
+
+test('ERC20 Approve Operation', async () => {
+  const erc20ApproveDeployParameters = new Erc20Approve(
+    '0168e3a352e7bab76c85fb77f7c641d77096dae55845c79655522c24e9cc1ffe21',
+    '1',
+    '015acde48328ae5ae008ecd27a4671f7b967b5c89477d1315265e762c7f07fe52c',
+    'casper-test',
+    'aee8a7ff16b770382aedf1a4cc83948613f315dc4f9560165f4feaa80fde5ac1',
+  );
+  const deploy = erc20ApproveDeployParameters.makeDeploy;
+  const result = DeployUtil.validateDeploy(deploy);
+  expect(result.ok)
+    .toBe(true);
+});
+
+test('ERC20 Transfer Operation', async () => {
+  const erc20TransferDeployParameters = new Erc20Transfer(
+    '0168e3a352e7bab76c85fb77f7c641d77096dae55845c79655522c24e9cc1ffe21',
+    '1',
+    '015acde48328ae5ae008ecd27a4671f7b967b5c89477d1315265e762c7f07fe52c',
+    'casper-test',
+    'aee8a7ff16b770382aedf1a4cc83948613f315dc4f9560165f4feaa80fde5ac1',
+  );
+  const deploy = erc20TransferDeployParameters.makeDeploy;
+  const result = DeployUtil.validateDeploy(deploy);
+  expect(result.ok)
+    .toBe(true);
+});


### PR DESCRIPTION
This PR provides two new deploy parameters and two new deploy results to support ERC20 tokens `approve` and `transfer` operations.